### PR TITLE
build pdf-to-civiform docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,83 @@
+# System & editors
+.DS_Store
+.idea/
+.project
+.vscode
+*.iml
+*.swp
+diff_output/
+updated_snapshots/
+
+# Test artifacts
+.log
+flakes
+logs/
+
+# sbt artifacts
+.bsp/
+*.pem
+**/.ammonite/
+**/.bloop/
+**/.data
+**/.metals/
+**/metals.sbt
+*/.classpath
+/browser-test/sbt_cache/*
+!/browser-test/sbt_cache/.keep
+sbt_cache/*
+!sbt_cache/.keep
+server/.settings/org.eclipse.*
+target/
+test-support/sbt_cache/
+
+# top-level project folder from running sbt in the wrong location
+/project/
+
+# node packages
+bundle.js
+node_modules
+
+# Terraform & docker artifacts
+.dockerlogs
+.terraform.tfstate**
+*_override.tf
+*.pyc
+*.terraform
+*.terraform.lock.hcl
+*.tfvars
+*_backend_vars
+backend_vars
+terraform_plan
+terraform.tfstate**
+!*example.auto.tfvars
+
+# secrets, run files, & exports
+.secrets
+*.bkp
+*.dump
+*civiform_config.sh
+civiform_config.sh
+gh-release-token.txt
+pom.xml
+RUNNING_PID
+server/code-coverage/*
+
+# Compiled css
+tailwind.css
+
+# env-var-doc python things
+env-var-docs/venv
+env-var-docs/**/*build
+env-var-docs/**/*.egg*
+.coverage
+coverage.xml
+
+# Python
+.venv/
+__pycache__/
+
+# Output of bin/dependency-tree
+dependency-tree.txt
+server/dependency-tree.txt
+dependencies-compile.graphml
+server/dependencies-compile.graphml

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -1,0 +1,123 @@
+#! /usr/bin/env bash
+
+# DOC: Build a new pdf-to-civiform development docker image
+# DOC: Optional environment variables:
+# DOC:   PUSH_IMAGE - Push the newly built image to registry if set to any value
+# DOC:   NAMESPACE  - Overrides the default docker namespace 'pdf-to-civiform'.
+# DOC:                Example: us-west1-docker.pkg.dev/my-gcp-project/my-repo
+# DOC:   PLATFORM   - Platform architecture to build (e.g. linux/amd64, linux/arm64)
+
+set -euo pipefail # Exit on error, undefined variable, pipe failures
+
+# --- Determine Project Root ---
+# Assumes this script is in project_root/bin/
+cd "$(dirname "$0")" # Go to bin/ directory
+readonly PROJECT_ROOT="$(cd .. && pwd)" # Go up one level to get project root
+cd "${OLDPWD}" # Go back to original directory
+
+# --- Configuration ---
+readonly DEFAULT_NAMESPACE="pdf-to-civiform" # Default local namespace
+readonly NAMESPACE="${NAMESPACE:=${DEFAULT_NAMESPACE}}"
+readonly IMAGE="pdf-to-civiform-dev" # Image name component
+readonly TAG="latest"                # Development tag
+readonly FULL_IMAGE_NAME="${NAMESPACE}/${IMAGE}:${TAG}" # Fully namespaced image name
+readonly LOCAL_TAG_NAME="${IMAGE}:${TAG}"             # Simpler local tag
+readonly SRC_DIR="${PROJECT_ROOT}/src/pdf_to_json"    # Source code / build context
+readonly DOCKERFILE="${SRC_DIR}/Dockerfile"           # Path to Dockerfile
+
+# --- Build Arguments ---
+# These are passed to 'docker buildx build'
+BUILD_ARGS=(
+  # Specify the Dockerfile location relative to the build context
+  --file "${DOCKERFILE}"
+  # Tag the image with the full namespace
+  --tag "${FULL_IMAGE_NAME}"
+  # Attempt to use cache from previous builds of the same tagged image in the registry
+  --cache-from "type=registry,ref=${FULL_IMAGE_NAME}"
+  # Embed cache metadata in the image for faster layer reuse
+  --build-arg BUILDKIT_INLINE_CACHE=1
+  # Load the built image into the local Docker daemon
+  --load
+  # The last argument is the build context directory
+  "${SRC_DIR}"
+)
+
+# Handle optional platform argument for cross-compilation
+PLATFORM_ARG=()
+if [[ -n "${PLATFORM:-}" ]]; then
+  echo "Building for specified platform: ${PLATFORM}"
+  PLATFORM_ARG=(--platform "${PLATFORM}")
+else
+  echo "Building for local platform architecture."
+fi
+
+# --- Docker Login Helper ---
+# Checks if login seems necessary and attempts login if PUSH_IMAGE is set
+docker::do_docker_login() {
+  local registry_host=""
+  # Extract registry hostname if namespace looks like a registry path
+  if [[ "${NAMESPACE}" == *"/"* ]]; then
+    registry_host=$(echo "${NAMESPACE}" | cut -d'/' -f1)
+    # Avoid treating default namespace as a registry host unless it contains '.'
+    if [[ "${registry_host}" == "${DEFAULT_NAMESPACE}" && "${registry_host}" != *.* ]]; then
+       registry_host="" # Assume default Docker Hub or local
+    fi
+  fi
+
+  # Crude check if logged in - might need adjustment for specific registries
+  # Tries to grep for Username or the specific Registry host in docker info
+  local login_check_pattern="Username:"
+  if [[ -n "${registry_host}" ]]; then
+      login_check_pattern+="|Registry: ${registry_host}"
+  fi
+
+  if ! docker info | grep -q -E "(${login_check_pattern})" ; then
+    echo "Attempting Docker login${registry_host:+ to ${registry_host}}..."
+    if [[ -n "${registry_host}" ]]; then
+        docker login "${registry_host}"
+    else
+        docker login # Login to default registry (usually Docker Hub)
+    fi
+  else
+    echo "Docker login detected${registry_host:+ for ${registry_host}}."
+  fi
+}
+
+# --- Build ---
+echo "Starting ${IMAGE} build from context: ${SRC_DIR}"
+echo "Command: docker buildx build ${PLATFORM_ARG[*]:-} ${BUILD_ARGS[*]}"
+docker buildx build "${PLATFORM_ARG[@]}" "${BUILD_ARGS[@]}"
+echo "Build complete. Image available as: ${FULL_IMAGE_NAME}"
+
+# --- Push (Optional) ---
+# Executes if the PUSH_IMAGE environment variable is set to any non-empty value
+if [[ -n "${PUSH_IMAGE:-}" ]]; then
+  echo "PUSH_IMAGE set. Attempting to push..."
+  # Ensure logged in before pushing
+  docker::do_docker_login
+
+  # Define arguments specifically for the push command (using --push instead of --load)
+  PUSH_BUILD_ARGS=(
+    --file "${DOCKERFILE}"
+    --tag "${FULL_IMAGE_NAME}"
+    # Use cache from registry when pushing
+    --cache-from "type=registry,ref=${FULL_IMAGE_NAME}"
+    # Inline cache for future builds
+    --build-arg BUILDKIT_INLINE_CACHE=1
+    # Add the --push flag
+    --push
+    # Build context directory
+    "${SRC_DIR}"
+   )
+  echo "Pushing ${FULL_IMAGE_NAME}..."
+  echo "Command: docker buildx build ${PLATFORM_ARG[*]:-} ${PUSH_BUILD_ARGS[*]}"
+  docker buildx build "${PLATFORM_ARG[@]}" "${PUSH_BUILD_ARGS[@]}"
+  echo "Push complete."
+fi
+
+# --- Local Tagging ---
+# Apply the simpler local tag (e.g., pdf-to-civiform-dev:latest) for convenience
+echo "Tagging ${FULL_IMAGE_NAME} as ${LOCAL_TAG_NAME} locally."
+docker tag "${FULL_IMAGE_NAME}" "${LOCAL_TAG_NAME}"
+
+echo "Build script finished."

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -16,7 +16,7 @@ readonly PROJECT_ROOT="$(cd .. && pwd)" # Go up one level to get project root
 cd "${OLDPWD}" # Go back to original directory
 
 # --- Configuration ---
-readonly DEFAULT_NAMESPACE="pdf-to-civiform" # Default local namespace
+readonly DEFAULT_NAMESPACE="civiform"
 readonly NAMESPACE="${NAMESPACE:=${DEFAULT_NAMESPACE}}"
 readonly IMAGE="pdf-to-civiform-dev" # Image name component
 readonly TAG="latest"                # Development tag

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -1,0 +1,83 @@
+#! /usr/bin/env bash
+
+# DOC: Run the pdf-to-civiform app locally using Docker.
+
+set -euo pipefail # Exit on error, undefined variable, pipe failures
+
+# --- Configuration ---
+readonly IMAGE="pdf-to-civiform-dev" # Simple local image name component
+readonly TAG="latest"
+readonly FULL_IMAGE_NAME="${IMAGE}:${TAG}" # Image tag to run
+readonly CONTAINER_NAME="pdf-to-civiform-local" # Name for the running container
+readonly PORT_MAPPING="7000:7000" # Map host port 7000 to container port 7000
+
+# --- Cleanup Function ---
+# This function is called when the script exits or receives SIGINT (Ctrl+C)
+cleanup() {
+  # Adding >&2 redirects echo output to stderr, preventing it from interfering
+  # with potential script output redirection. Good practice for informational messages.
+  echo "" >&2 # Newline after potential Ctrl+C output
+  echo "Interrupt received. Cleaning up..." >&2
+  echo "Stopping container ${CONTAINER_NAME}..." >&2
+  # Stop the container, ignoring errors if it's already stopped (|| true)
+  docker stop "${CONTAINER_NAME}" > /dev/null || true
+  echo "Removing container ${CONTAINER_NAME}..." >&2
+  # Remove the container, ignoring errors if it's already removed (|| true)
+  docker rm "${CONTAINER_NAME}" > /dev/null || true
+  echo "Cleanup finished." >&2
+  # Exit with status 0 to indicate successful cleanup
+  exit 0
+}
+
+# Trap the SIGINT signal (Ctrl+C) and the EXIT signal (script finishing normally or abnormally)
+# When trapped, execute the 'cleanup' function.
+trap cleanup SIGINT EXIT
+
+# --- Check if image exists ---
+echo "Checking if image ${FULL_IMAGE_NAME} exists..."
+# Inspect the image; redirect stdout and stderr to /dev/null. If the command fails (exit code != 0), the image doesn't exist.
+if ! docker image inspect "${FULL_IMAGE_NAME}" > /dev/null 2>&1; then
+  echo "Error: Image ${FULL_IMAGE_NAME} not found locally." >&2
+  echo "Please build the image first by running from project root: ./bin/build-dev" >&2
+  exit 1 # Exit script with an error status
+fi
+echo "Image found."
+
+# --- Stop and Remove Existing Container ---
+echo "Checking for existing container named ${CONTAINER_NAME}..."
+# List containers (including stopped ones -a) and filter by name.
+# Use grep -q for quiet mode (no output), just exit status.
+# Use ^...$ to match the exact name.
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+  echo "Stopping existing container ${CONTAINER_NAME}..."
+  docker stop "${CONTAINER_NAME}" > /dev/null || true
+  echo "Removing existing container ${CONTAINER_NAME}..."
+  docker rm "${CONTAINER_NAME}" > /dev/null || true
+fi
+
+# --- Run New Container ---
+echo "Starting container ${CONTAINER_NAME} from image ${FULL_IMAGE_NAME}..."
+# Run the container:
+# -d: Detached mode (runs in background)
+# -p: Publish ports (host:container)
+# --name: Assign a name to the container
+# Last argument is the image name to run
+docker run \
+  -d \
+  -p "${PORT_MAPPING}" \
+  --name "${CONTAINER_NAME}" \
+  "${FULL_IMAGE_NAME}"
+
+# Brief pause to allow the container's web server to initialize
+sleep 3
+
+# --- Follow Logs ---
+echo "Container started successfully. Access at http://localhost:7000 (or forwarded port)"
+echo "Following logs for ${CONTAINER_NAME} (Press Ctrl+C to stop and cleanup)..."
+# Fetch and follow logs (-f) from the specified container.
+# This command will block until interrupted (e.g., by Ctrl+C).
+docker logs -f "${CONTAINER_NAME}"
+
+# When 'docker logs -f' is interrupted (Ctrl+C), the script receives SIGINT.
+# The 'trap' command catches this and executes the 'cleanup' function.
+# The 'cleanup' function stops/removes the container and exits the script gracefully.

--- a/src/pdf_to_json/Dockerfile
+++ b/src/pdf_to_json/Dockerfile
@@ -1,0 +1,56 @@
+# Dockerfile (~/pdf-to-civiform/src/pdf_to_json/Dockerfile)
+FROM python:3.10-slim-buster
+
+ARG USER_NAME=cf-user
+ARG GROUP_NAME=cf-group
+ARG USER_HOME=/home/${USER_NAME}
+# WORK_DIR will be inside the user's home
+ARG WORK_DIR=${USER_HOME}/pdf_to_civiform
+ARG APP_DIR=${WORK_DIR}/app
+
+# Create group, user, and user's home directory
+RUN groupadd --system ${GROUP_NAME} && \
+    useradd --system --gid ${GROUP_NAME} --create-home --home-dir ${USER_HOME} ${USER_NAME}
+
+# Create the workdir, app dir, uploads, cache within user's home
+# Set ownership of the user's entire home dir structure early
+RUN mkdir -p ${APP_DIR} ${WORK_DIR}/uploads ${WORK_DIR}/python_cache && \
+    chown -R ${USER_NAME}:${GROUP_NAME} ${USER_HOME}
+
+# Set the working directory (Gunicorn will run from here)
+WORKDIR ${WORK_DIR}
+
+# Copy the dependencies file into the app directory
+# Need to switch user temporarily or adjust permissions/ownership later
+# Let's copy as root then chown later
+COPY python_dependencies.txt ${APP_DIR}/
+
+# Install dependencies
+RUN pip install --no-cache-dir -r ${APP_DIR}/python_dependencies.txt
+
+# Copy the application code into the app directory (relative to WORKDIR doesn't work here)
+COPY . ${APP_DIR}/
+
+## TODO - get Gemini API key for demo env
+# --- WARNING: Embedding API key in image is insecure ---
+# Copy the API key from the build context *root* to the WORKDIR
+# COPY google_api_key .
+
+# Change ownership of copied items (deps file, app code, api key)
+#RUN chown -R ${USER_NAME}:${GROUP_NAME} ${APP_DIR} ${WORK_DIR}/google_api_key
+
+# Add the app directory to the Python path
+ENV PYTHONPATH=${APP_DIR}
+
+# Use port 7000
+ENV PORT=7000
+ENV PYTHONUNBUFFERED=1
+
+# Switch to the non-root user
+USER ${USER_NAME}
+
+# Expose the port (runs as cf-user)
+EXPOSE 7000
+
+# Define the command to run Gunicorn (runs as cf-user from WORKDIR)
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --timeout 900 pdf_to_civiform_gemini:app"]

--- a/src/pdf_to_json/templates/index.html
+++ b/src/pdf_to_json/templates/index.html
@@ -349,7 +349,7 @@
           type="text"
           id="directoryPath"
           name="directoryPath"
-          value="~/pdf-to-civiform/pdf_forms"
+          value="~/pdf_to_civiform/uploads"
           size="50"
         />
         <button type="submit">Process Directory</button>


### PR DESCRIPTION
build pdf-to-civiform docker image which can run locally and on Cloud.

.gitignore was replicated from parent civiform repos

(plan to run pdf-to-civiform on GCP CloudRun)

fixes issue [#10094](https://github.com/civiform/civiform/issues/10094)