### PR TITLE
[pdf-to-civiform] add program instructions

### DIFF
--- a/src/pdf_to_json/README.md
+++ b/src/pdf_to_json/README.md
@@ -62,3 +62,5 @@ Import the generated CiviForm JSON into CiviForm using the "[Import program" flo
 3.  Click the "Import existing program" link.
 4.  Paste the content of the `PREFIX-civiform-MODEL.json` file into the text area.
 5.  Follow the on-screen instructions to complete the import.
+6.  Follow instructions at the ["Edit a program"](https://docs.civiform.us/user-manual/civiform-admin-guide/working-with-programs/edit-a-program) to edit the program and "["How to publish programs"](https://docs.civiform.us/user-manual/civiform-admin-guide/working-with-programs/publish-a-program).
+

--- a/src/pdf_to_json/convert_to_civiform_json.py
+++ b/src/pdf_to_json/convert_to_civiform_json.py
@@ -392,7 +392,7 @@ def convert_to_civiform_json(unprocessed_input_json):
                                     "translations":
                                         {
                                             "en_US":
-                                                "program-applicationSteps description TO-BE-EDITED"
+                                                input_json.get("Instructions") or "program-applicationSteps description TO-BE-EDITED"
                                         },
                                     "isRequired": True
                                 }


### PR DESCRIPTION
1. instruct LLM to summarize relevant program instructions.
2. extract fillable PDF dropdown menu items
3. abbreviate help text
4. add work around for radio button and checkbox options.   Needed to replicate in post processing step as Gemini did not always honor the instructions in the initial processing step

fixes: [#10215](https://github.com/civiform/civiform/issues/10215)