### PR TITLE
omit sections/questions for office administrative purposes

### DIFF
--- a/src/pdf_to_json/LLM_prompts.py
+++ b/src/pdf_to_json/LLM_prompts.py
@@ -10,7 +10,7 @@ JSON_EXAMPLE = {
             "help_text": "[Relevant Instructional or informational Text (can be enclosed in brackets)]",
             "fields": [
                 {"label": "[Field Label]", "type": "[Field Type]", "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"},
-                {"label": "[Field Label]", "type": "[radio]", "options": ["opt 1", "opt 2", "opt 3"], "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"},
+                {"label": "[Field Label]", "type": "[radio_button]", "options": ["opt 1", "opt 2", "opt 3"], "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"},
                 {"label": "[Field Label]", "type": "[checkbox]", "options": ["opt 1", "opt 2", "opt 3"], "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"}
             ]
         },
@@ -20,7 +20,7 @@ JSON_EXAMPLE = {
             "type": "repeating_section",
             "fields": [
                 {"label": "[Field Label]", "type": "[Field Type]", "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"},
-                {"label": "[Field Label]", "type": "[radio]", "options": ["opt 1", "opt 2", "opt 3"], "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"},
+                {"label": "[Field Label]", "type": "[radio_button]", "options": ["opt 1", "opt 2", "opt 3"], "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"},
                 {"label": "[Field Label]", "type": "[checkbox]", "options": ["opt 1", "opt 2", "opt 3"], "help_text": "[Field-specific Instruction]", "id": "[Generated Field ID]"}
             ]
         },
@@ -58,6 +58,8 @@ class LLMPrompts:
         Every section must have a meaningful title and at least one field.
 
         For fillable PDF files, make sure you extract dropdown options. 
+
+        Omit any sections clearly marked "For Office Use Only" or similar administrative purposes.
 
         Make sure to consider the following rules to extract input fields and types:
         1. **Address**: address (e.g., residential, work, mailing). Unit, city, zip code, street, municipality, county, district etc are included. Please collate them into a single field.

--- a/src/pdf_to_json/LLM_prompts.py
+++ b/src/pdf_to_json/LLM_prompts.py
@@ -59,7 +59,7 @@ class LLMPrompts:
 
         For fillable PDF files, make sure you extract dropdown options. 
 
-        Omit any sections clearly marked "For Office Use Only" or similar administrative purposes.
+        Omit any sections clearly marked "For Office Use Only", "For Administrative Use", "For Agency Use" or similar administrative purposes.
 
         Make sure to consider the following rules to extract input fields and types:
         1. **Address**: address (e.g., residential, work, mailing). Unit, city, zip code, street, municipality, county, district etc are included. Please collate them into a single field.

--- a/src/pdf_to_json/convert_to_civiform_json.py
+++ b/src/pdf_to_json/convert_to_civiform_json.py
@@ -32,7 +32,7 @@ def replace_field_types(data):
     if isinstance(data, dict):
         if "type" in data:
             data["type"] = data["type"].lower()
-            if data["type"] not in ("name", "text", "number", "radio",
+            if data["type"] not in ("name", "text", "number", "radio_button",
                                     "checkbox", "currency", "date", "email",
                                     "address", "phone", "repeating_section",
                                     "fileupload"):
@@ -58,7 +58,7 @@ def replace_field_types(data):
 
 
 def create_question(field, question_id, enumerator_id=None):
-    is_multioption = field["type"] in ["radio", "checkbox", "dropdown"]
+    is_multioption = field["type"] in ["radio_button", "checkbox", "dropdown"]
     is_enumerator = field["type"] == "enumerator"
     is_fileupload = field["type"] == "fileupload"
 
@@ -134,7 +134,7 @@ def create_question(field, question_id, enumerator_id=None):
             )
 
         # Check the number of options for radio buttons
-        if field["type"] == "radio" and len(question_options) < 2:
+        if field["type"] == "radio_button" and len(question_options) < 2:
             logging.error(
                 f"ERROR: Radio button question '{field['label']}' must have at least two options."
             )
@@ -153,7 +153,7 @@ def create_question(field, question_id, enumerator_id=None):
 
         question["questionOptions"] = question_options
         question["multiOptionQuestionType"] = "RADIO_BUTTON" if field[
-            "type"] == "radio" else "CHECKBOX"
+            "type"] == "radio_button" else "CHECKBOX"
         question["optionAdminNames"] = option_admin_names
         question["options"] = question_options
 
@@ -186,7 +186,7 @@ def create_question(field, question_id, enumerator_id=None):
     elif question["type"] == "multioption":
         question["config"]["validationPredicates"]["minChoicesRequired"] = 1
         # Set maxChoicesAllowed to 1 if it's a radio button question
-        if field["type"] == "radio":
+        if field["type"] == "radio_button":
             question["config"]["validationPredicates"]["maxChoicesAllowed"] = 1
         else:  # For other multioption types (like checkbox), keep the original logic
             question["config"]["validationPredicates"][

--- a/src/pdf_to_json/templates/index.html
+++ b/src/pdf_to_json/templates/index.html
@@ -230,7 +230,8 @@
 <h2>Convert one PDF:</h2>
 
     <form onsubmit="uploadFile(event)" class="form-group">
-    <input type="file" id="pdfFile" accept="application/pdf" required />
+      <label for="fileInput">Upload a PDF file:</label>
+      <input type="file" id="pdfFile" accept="application/pdf" required />
       <button type="submit">Convert a single PDF file</button>
     </form>
 


### PR DESCRIPTION
amend LLM prompt to omit "office only" sections/questions on forms.

clean up "radio" type in the sample json to align with civiform type "radio_button"