### PR TITLE
Make gemini-2.0-flash the default

### DIFF
--- a/src/pdf_to_json/templates/index.html
+++ b/src/pdf_to_json/templates/index.html
@@ -260,8 +260,10 @@
       <div class="form-group">
         <label for="LLMModelSelect">Gemini Model:</label>
         <select id="LLMModelSelect">
-          <option value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
           <option value="gemini-2.0-flash">gemini-2.0-flash</option>
+          <option value="gemini-2.0-flash-lite">gemini-2.0-flash-lite</option>
+          <option value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
+          <option value="gemini-2.5-flash-preview-04-17">gemini-2.5-flash-preview-04-17</option>
         </select>
       </div>
       <div class="form-group">

--- a/src/pdf_to_json/templates/index.html
+++ b/src/pdf_to_json/templates/index.html
@@ -260,10 +260,10 @@
       <div class="form-group">
         <label for="LLMModelSelect">Gemini Model:</label>
         <select id="LLMModelSelect">
-          <option value="gemini-2.0-flash">gemini-2.0-flash</option>
+          <option value="gemini-2.0-flash" selected>gemini-2.0-flash</option>
           <option value="gemini-2.0-flash-lite">gemini-2.0-flash-lite</option>
-          <option value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
           <option value="gemini-2.5-flash-preview-04-17">gemini-2.5-flash-preview-04-17</option>
+          <option value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
         </select>
       </div>
       <div class="form-group">

--- a/src/pdf_to_json/templates/index.html
+++ b/src/pdf_to_json/templates/index.html
@@ -262,8 +262,6 @@
         <select id="LLMModelSelect">
           <option value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
           <option value="gemini-2.0-flash">gemini-2.0-flash</option>
-          <option value="gemini-2.0-flash-lite">gemini-2.0-flash-lite</option>
-          <option value="gemini-2.5-flash-preview-04-17">gemini-2.5-flash-preview-04-17</option>
         </select>
       </div>
       <div class="form-group">


### PR DESCRIPTION
Gemini-2.0-flash is the most reliable model ATM:
https://docs.google.com/spreadsheets/d/1xF1DMOtYzQJp9w3fZUN6vK_F_Z4nN4JSX12hJYdkHAs/edit?gid=0#gid=0

(Also, I added two new models to the web app in the last PR, but forgot to mention it in the description – so mentioning it here.)