### PR TITLE
Remove unnecessary parameter from LLM initialization

### DIFF
--- a/src/pdf_to_json/llm_lib.py
+++ b/src/pdf_to_json/llm_lib.py
@@ -10,21 +10,20 @@ import traceback
 
 PAGE_LIMIT=5
 
-def initialize_gemini_model(
-    model_name="gemini-2.0-flash",
+def initialize_gemini_client(
     api_key=None,
     api_key_file=os.path.expanduser("~/google_api_key")):
     """
     Initializes and configures the Gemini GenerativeModel.
 
     Args:
-        model_name (str): The name of the Gemini model to use.
         api_key (str, optional): API key provided by the user. Defaults to None.
         api_key_file (str): The path to the file containing the Google API key.
 
     Returns:
         genai.Client: The initialized Gemini client.
     """
+
     try:
         loaded_api_key = None
         if api_key:

--- a/src/pdf_to_json/pdf_to_civiform_gemini.py
+++ b/src/pdf_to_json/pdf_to_civiform_gemini.py
@@ -29,7 +29,7 @@ import argparse # Import argparse
 # output files are stored in ~/pdf_to_civiform/output-json
 
 # --- Global Configuration ---
-DEFAULT_MODEL_NAME = "gemini-2.0-flash" # Default model used in initialize_gemini_model
+DEFAULT_MODEL_NAME = "gemini-2.0-flash"
 
 # Configure logging (Initial setup, level can be changed later via CLI)
 logging.basicConfig(
@@ -212,7 +212,7 @@ def upload_file():
         logging.info(f"Log level set to: {logging.getLevelName(log_level)}")
         logging.info(f"Using model for request: {model_name}")
 
-        client = llm.initialize_gemini_model(model_name=model_name, api_key=gemini_api_key)
+        client = llm.initialize_gemini_client(api_key=gemini_api_key)
         if client is None:
             error_message = "Failed to initialize Gemini client. Check API key configuration and logs."
             logging.error(error_message)
@@ -415,7 +415,7 @@ def upload_directory():
         return jsonify({"error": "Invalid directory path.", "debug_log": debug_log}), 400
 
 
-    client = llm.initialize_gemini_model(model_name, api_key=gemini_api_key)
+    client = llm.initialize_gemini_client(api_key=gemini_api_key)
     if client is None:
         error_message = "Failed to initialize Gemini client. Check API key or file."
         logging.error(error_message)
@@ -499,10 +499,10 @@ if __name__ == '__main__':
             logging.error(f"Input file not found or is not a file: {input_path}")
             sys.exit(1) # Exit with error code
 
-        # Initialize Gemini Client using the specified model name
+        # Initialize Gemini Client.
         # API key is handled internally by the function (reading from file)
-        logging.info(f"Initializing Gemini client for model: {args.model_name}")
-        client = llm.initialize_gemini_model(model_name=args.model_name) # Pass only model name
+        logging.info(f"Initializing Gemini client")
+        client = llm.initialize_gemini_client()
         if client is None:
             logging.error("Failed to initialize Gemini client. Check API key file/access. Exiting.")
             sys.exit(1)

--- a/src/pdf_to_json/regression_test.py
+++ b/src/pdf_to_json/regression_test.py
@@ -78,12 +78,13 @@ def calculate_score(json_golden_str, json_eval_str):
     return score
 
 
-def regression_test(llm_client, directory):
+def regression_test(llm_client, directory, model_name):
     """ Evaluate all of the PDF/JSON pairs in a directory.
 
     Args:
       llm_client: An initialized LLM object.
       directory: The name of the directory containing golden PDF/JSON pairs.
+      model_name: Name of the LLM to use (e.g., "gemini-2.0-flash")
 
     Returns:
       A dict mapping the PDF filepaths to their regression scores.
@@ -104,7 +105,9 @@ def regression_test(llm_client, directory):
 
             # Run the pipeline.
             subprocess.run(['python3', './pdf_to_civiform_gemini.py',
-                            '--input-file', pdf])
+                            '--input-file', pdf,
+                            '--model-name', model_name,
+                            ])
 
             # TODO(orwant): Fix pdf_to_civiform_gemini to take
             # work directories & filenames as arguments. Otherwise,
@@ -147,7 +150,7 @@ def display_scores(scores):
 
 if __name__ == '__main__':
     args = parse_arguments()
-    llm_client = llm.initialize_gemini_model(model_name = args.model)
-    scores = regression_test(llm_client, args.directory)
+    llm_client = llm.initialize_gemini_client()
+    scores = regression_test(llm_client, args.directory, args.model)
     display_scores(scores)
         


### PR DESCRIPTION
initialize_gemini_model() never uses the model parameter! It just initializes the Gemini _client_. Fixing the invocations to reflect that.

TESTED=regression_test