### PR TITLE
Add question similarity rule

### DIFF
--- a/src/pdf_to_json/regression_test_rules.py
+++ b/src/pdf_to_json/regression_test_rules.py
@@ -12,6 +12,11 @@ import json
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
+# When mapping questions from one program to another, this constant
+# is used to ensure that the questions aren't too far away.
+# The lower this constant, the more likely that a question close to
+# the beginning of one program will be mapped to a question at the end
+# of the other.
 _INDEX_PENALTY_EXPONENT = 0.9
 
 def score_missed_questions(num_json_questions, num_golden_questions):
@@ -174,7 +179,7 @@ def extract_question_texts(json_str):
 def generate_question_similarity_matrix(json_golden_str, json_eval_str):
     """ Generate the similarity matrix of questions in two programs.
 
-     The similarity matrix has dimension N x M, where N is the number of
+    The similarity matrix has dimension N x M, where N is the number of
     questions with text in the golden program, and M the number of questions
     with text in the eval program. When the pipeline is operating
     perfectly, that matrix will be the identity matrix, and so the return

--- a/src/pdf_to_json/regression_test_rules.py
+++ b/src/pdf_to_json/regression_test_rules.py
@@ -12,6 +12,7 @@ import json
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
+_INDEX_PENALTY_EXPONENT = 0.9
 
 def score_missed_questions(num_json_questions, num_golden_questions):
     """ Score the number of missed questions.
@@ -169,43 +170,29 @@ def extract_question_texts(json_str):
                 result.append(question['config']['description'])
     return result
 
-def rule_help_text_similarity(json_golden_str, json_eval_str):
-    """ Compute the similarity of the help texts in two programs.
 
-    This rule compares the help texts of two programs. Often the
-    PDF->CiviForm pipeline will generate a different number of questions
-    than the "golden" CiviForm -- and even generate a different number
-    of questions from run to run.
+def generate_question_similarity_matrix(json_golden_str, json_eval_str):
+    """ Generate the similarity matrix of questions in two programs.
 
-    We therefore need a way to establish a mapping between the questions
-    in the two programs. To do this, we create a TF-IDF embedding and use
-    the highest values in the similarity matrix to establish that mapping.
-
-    The similarity matrix has dimension N x M, where N is the number of
+     The similarity matrix has dimension N x M, where N is the number of
     questions with text in the golden program, and M the number of questions
     with text in the eval program. When the pipeline is operating
     perfectly, that matrix will be the identity matrix, and so the return
     value of this method will be 1.0.
-
-    When the pipeline is not perfect, it may generate a different number
-    of questions than the golden program. In that case the highest value
-    of the appropriate column in the matrix is the closest question, and
-    its magnitude indicates the similarity of the texts in those two
-    questions.
 
     Args:
       json_golden_str: A JSON string of the golden program.
       json_eval_str: A JSON string of the program to be evaluated.
 
     Returns:
-      Float in [0.0, 1.0] indicating the similarity of the question texts.
+      A 2D matrix of the similarities between program questions.
     """
     # First, extract the question texts.
     questions_golden = extract_question_texts(json_golden_str)
     questions_eval = extract_question_texts(json_eval_str)
 
     if len(questions_golden) == 0 or len(questions_eval) == 0:
-        return 0.0
+        return [[]]
 
     # Create a joint question corpus for TF-IDF calculations.
     # If we knew that the number of questions in each program was the same,
@@ -221,6 +208,88 @@ def rule_help_text_similarity(json_golden_str, json_eval_str):
     # Compute the similarity matrix.
     similarity_matrix = cosine_similarity(
         tfidf_matrix_golden, tfidf_matrix_eval)
+
+    return similarity_matrix
+
+
+def generate_question_mapping(json_golden_str, json_eval_str):
+    """ Map the questions between programs using question texts.
+
+    Args:
+      json_golden_str: A JSON string of the golden program.
+      json_eval_str: A JSON string of the program to be evaluated.
+
+    Returns:
+      Two arrays, one mapping questions from the golden to the eval,
+      and the other mapping from eval to the golden.
+    """
+
+    similarity_matrix = generate_question_similarity_matrix(
+        json_golden_str, json_eval_str)
+
+    def index_penalty(index1, index2):
+        return _INDEX_PENALTY_EXPONENT ** abs(index1 - index2)
+
+    # First, loop by row to find the golden->eval mappings.
+    # This gets a little complicated. Instead of always picking the question
+    # with the highest similarity, we penalize based on distance in the array,
+    # so that if there are two questions that seem similar based on wording,
+    # we choose the one whose index is closest to the golden index.
+    golden_to_eval = [None] * len(similarity_matrix)
+    for golden_index in range(len(similarity_matrix)):
+        best_index = -1
+        best_value = 0
+        for eval_index in range(len(similarity_matrix[0])):
+            penalized_value = (index_penalty(golden_index, eval_index) *
+                               similarity_matrix[golden_index][eval_index])
+            if (best_value <= penalized_value):
+                best_index = eval_index
+                best_value = penalized_value
+        golden_to_eval[golden_index] = best_index
+
+    # Now, the converse: loop by column to find the eval->golden mappings.
+    # These are not guaranteed to be symmetrical!
+    eval_to_golden = [None] * len(similarity_matrix[0])
+    for eval_index in range(len(similarity_matrix[0])):
+        best_index = -1
+        best_value = 0
+        for golden_index in range(len(similarity_matrix)):
+            penalized_value = (index_penalty(golden_index, eval_index) *
+                               similarity_matrix[golden_index][eval_index])
+            if (best_value <= penalized_value):
+                best_index = eval_index
+                best_value = penalized_value
+        eval_to_golden[eval_index] = best_index
+
+    return(golden_to_eval, eval_to_golden)
+
+def rule_help_text_similarity(json_golden_str, json_eval_str):
+    """ Compute the similarity of the help texts in two programs.
+
+    This rule compares the help texts of two programs. Often the
+    PDF->CiviForm pipeline will generate a different number of questions
+    than the "golden" CiviForm -- and even generate a different number
+    of questions from run to run.
+
+    We therefore need a way to establish a mapping between the questions
+    in the two programs. To do this, we create a TF-IDF embedding and use
+    the highest values in the similarity matrix to establish that mapping.
+
+    When the pipeline is not perfect, it may generate a different number
+    of questions than the golden program. In that case the highest value
+    of the appropriate column in the matrix is the closest question, and
+    its magnitude indicates the similarity of the texts in those two
+    questions.
+
+    Args:
+      json_golden_str: A JSON string of the golden program.
+      json_eval_str: A JSON string of the program to be evaluated.
+
+    Returns:
+      Float in [0.0, 1.0] indicating the similarity of the question texts.
+    """
+    similarity_matrix = generate_question_similarity_matrix(
+        json_golden_str, json_eval_str)
 
     # Average the highest scores.
     sum = 0.0

--- a/src/pdf_to_json/regression_test_rules_test.py
+++ b/src/pdf_to_json/regression_test_rules_test.py
@@ -55,11 +55,20 @@ class TestRuleHelpTextSimilarity(unittest.TestCase):
             'testdata/goldens/seattle_homewise.json')
         self.business_str = read_file_into_string(
             'testdata/goldens/charlotte_business.json')
+        self.leadsafe_str = read_file_into_string(
+            'testdata/goldens/charlotte_leadsafe.json')
+        self.leadsafe_tweaked_str = read_file_into_string(
+            'testdata/programs/charlotte_leadsafe_question_tweak.json')
 
     def test_self_similarity(self):
         self.assertGreater(
             rules.rule_help_text_similarity(self.homerepair_str,
                                             self.homerepair_str), 0.99)
+    def test_high_similarity(self):
+        self.assertGreater(
+            rules.rule_help_text_similarity(self.leadsafe_str,
+                                            self.leadsafe_tweaked_str), 0.8)
+
     def test_medium_similarity(self):
         self.assertGreater(
             rules.rule_help_text_similarity(self.homerepair_str,
@@ -68,6 +77,26 @@ class TestRuleHelpTextSimilarity(unittest.TestCase):
         self.assertLess(
             rules.rule_help_text_similarity(self.homewise_str,
                                             self.business_str), 0.5)
-        
+
+
+class TestGenerateQuestionMapping(unittest.TestCase):
+
+    def setUp(self):
+        self.homerepair_str = read_file_into_string(
+            'testdata/goldens/seattle_home_repair_loan.json')
+        self.homewise_str = read_file_into_string(
+            'testdata/goldens/seattle_homewise.json')
+        self.tree_canopy_str = read_file_into_string(
+            'testdata/goldens/charlotte_tree_canopy.json')
+        self.leadsafe_str = read_file_into_string(
+            'testdata/goldens/charlotte_leadsafe.json')
+
+    def test_self_similarity(self):
+        (golden_to_eval, eval_to_golden) = (
+            rules.generate_question_mapping(self.homerepair_str,
+                                            self.homerepair_str))
+        self.assertEqual(golden_to_eval[0], 0)
+        self.assertEqual(golden_to_eval[15], 15)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
To calculate the fidelity of an AI-generated CiviForm program, we want to be able to compare questions between a golden program and the generated program. 

That requires:
- Understanding how the questions in the golden program map to the questions in the eval program. (The AI pipeline often generates a different number of questions from run to run.)
- Given two questions, how similar are the help texts? (Future PRs will take the question _type_ into account.)

This PR gets us partway there, by:
- Defining a method that maps questions in the golden program to questions in the eval program, and vice versa.
- Defining a rule that calculates the fidelity of two programs given their question help text.

Note: TestGenerateQuestionMapping() reads in some programs and then doesn't use them. That's for a future test in the next PR. (Why not this PR? Because it looks like the golden PDFs and golden JSONs don't match and I need to investigate.)

TESTED=regression_test_rules_test
