### PR TITLE
Include latest Gemini models

### DIFF
--- a/src/pdf_to_json/templates/index.html
+++ b/src/pdf_to_json/templates/index.html
@@ -261,9 +261,11 @@
         <label for="LLMModelSelect">Gemini Model:</label>
         <select id="LLMModelSelect">
           <option value="gemini-2.0-flash" selected>gemini-2.0-flash</option>
+          <option value="gemini-2.5-flash" selected>gemini-2.5-flash</option>
           <option value="gemini-2.0-flash-lite">gemini-2.0-flash-lite</option>
-          <option value="gemini-2.5-flash-preview-04-17">gemini-2.5-flash-preview-04-17</option>
+          <option value="gemini-2.5-flash-lite-preview-06-17">gemini-2.5-flash-lite-preview-06-17</option>
           <option value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
+          <option value="gemini-2.5-pro">gemini-2.5-pro</option>
         </select>
       </div>
       <div class="form-group">


### PR DESCRIPTION
Allows users to select more recent releases (such as 2.5 models) from the Gemini model dropdown.