### PR TITLE
Add new displayMode attribute to question JSON

### DIFF
--- a/src/pdf_to_json/convert_to_civiform_json.py
+++ b/src/pdf_to_json/convert_to_civiform_json.py
@@ -131,6 +131,7 @@ def create_question(field, question_id, enumerator_id=None):
                     },
                 "id": question_id,
                 "universal": False,
+                "displayMode" : "VISIBLE",
                 "primaryApplicantInfoTags": []
             }
     }


### PR DESCRIPTION
We recently added a new attribute for questions called `displayMode`. In order to maintain compatibility with the data schema, the AI tool should also include this attribute in its output.